### PR TITLE
Fix `toBeRejected` signature

### DIFF
--- a/.changeset/polite-pots-smash.md
+++ b/.changeset/polite-pots-smash.md
@@ -1,0 +1,6 @@
+---
+'earljs': patch
+---
+
+Tweak `toBeRejected` validator signature to be properly async (return
+`Promise<void>`). This was a bug in typings not in behaviour.

--- a/src/Expectation.ts
+++ b/src/Expectation.ts
@@ -55,9 +55,9 @@ export class Expectation<T> {
     }
   }
 
-  toBeRejected(this: Expectation<Promise<any>>): void
-  toBeRejected(this: Expectation<Promise<any>>, expectedMsg: string): void
-  toBeRejected(this: Expectation<Promise<any>>, errorCls: Newable<Error>, expectedMsg?: string): void
+  toBeRejected(this: Expectation<Promise<any>>): Promise<void>
+  toBeRejected(this: Expectation<Promise<any>>, expectedMsg: string): Promise<void>
+  toBeRejected(this: Expectation<Promise<any>>, errorCls: Newable<Error>, expectedMsg?: string): Promise<void>
   toBeRejected(
     this: Expectation<Promise<any>>,
     errorClsOrExpectedMsg?: string | Newable<Error>,

--- a/test/validators/toBeRejected.test.ts
+++ b/test/validators/toBeRejected.test.ts
@@ -5,9 +5,9 @@ import { expect as earl } from '../../src'
 describe('toBeRejected', () => {
   describe('with msg string', () => {
     it('works', async () => {
-      const run = earl(Promise.reject(new Error('Test msg'))).toBeRejected('Test msg')
+      const result = await earl(Promise.reject(new Error('Test msg'))).toBeRejected('Test msg')
 
-      await expect(run).to.be.eventually.undefined
+      expect(result).to.be.undefined
     })
 
     it('throws on msg mismatch', async () => {


### PR DESCRIPTION
Closes: https://github.com/earl-js/earl/issues/64