### PR TITLE
Make `expect.a(Array)` return type be `any[]` not `unknown[]`

### DIFF
--- a/.changeset/fuzzy-lions-exercise.md
+++ b/.changeset/fuzzy-lions-exercise.md
@@ -1,0 +1,6 @@
+---
+'earljs': patch
+---
+
+Made `expect.a(Array)` return type be `any[]` not `unknown[]` which works well
+with `toEqual`.

--- a/packages/earljs/src/matchers/A.ts
+++ b/packages/earljs/src/matchers/A.ts
@@ -15,6 +15,8 @@ export type Class2Primitive<T> = T extends String
   ? symbol
   : T extends Exact<Object, T>
   ? any
+  : T extends Array<any>
+  ? any[]
   : T
 
 /**

--- a/packages/earljs/test/matchers/A.test.ts
+++ b/packages/earljs/test/matchers/A.test.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai'
 
+import { expect as earlExpect } from '../../src'
 import { AMatcher } from '../../src/matchers/A'
 
 describe('A matcher', () => {
@@ -104,5 +105,11 @@ describe('A matcher', () => {
     expect(m.check(undefined)).to.be.false
     expect(m.check(null)).to.be.false
     expect(m.check({})).to.be.false
+  })
+
+  describe('in expectation', () => {
+    it('works with arrays', () => {
+      earlExpect([1, 2, 3]).toEqual(earlExpect.a(Array))
+    })
   })
 })


### PR DESCRIPTION
Closes: https://github.com/earl-js/earl/issues/84