### PR TITLE
Tweak `toHaveBeenCalledExactlyWith` types

### DIFF
--- a/.changeset/dry-apes-act.md
+++ b/.changeset/dry-apes-act.md
@@ -1,0 +1,5 @@
+---
+'earljs': patch
+---
+
+Tweak `toHaveBeenCalledExactlyWith` input type to properly support arrays

--- a/packages/earljs/src/Expectation.ts
+++ b/packages/earljs/src/Expectation.ts
@@ -87,7 +87,7 @@ export class Expectation<T> {
     return toHaveBeenCalledWith(this.getControl(), expectedCall)
   }
 
-  toHaveBeenCalledExactlyWith(this: Expectation<Mock<any[], any>>, expectedCalls: MockArgs<T>) {
+  toHaveBeenCalledExactlyWith(this: Expectation<Mock<any[], any>>, expectedCalls: MockArgs<T>[]) {
     return toHaveBeenCalledExactlyWith(this.getControl(), expectedCalls)
   }
 

--- a/packages/earljs/test/validators/mocks/toHaveBeenCalledExactlyWith.test.ts
+++ b/packages/earljs/test/validators/mocks/toHaveBeenCalledExactlyWith.test.ts
@@ -2,36 +2,37 @@ import { expect } from 'chai'
 
 import { expect as earl } from '../../../src'
 import { mockFn } from '../../../src/mocks'
-import { noop } from '../../common'
+
+const sum = (a: number, b: number) => a + b
 
 describe('toHaveBeenCalledExactlyWith', () => {
   describe('not negated', () => {
     it('works when was called with a given args', () => {
-      const mock = mockFn(noop)
+      const mock = mockFn(sum)
 
-      mock(1, 2, 3)
+      mock(1, 2)
 
-      expect(() => earl(mock).toHaveBeenCalledExactlyWith([[1, 2, 3]])).not.to.throw()
+      expect(() => earl(mock).toHaveBeenCalledExactlyWith([[1, 2]])).not.to.throw()
     })
 
     it('works when was not called at all', () => {
-      const mock = mockFn(noop)
+      const mock = mockFn(sum)
 
       expect(() => earl(mock).toHaveBeenCalledExactlyWith([])).not.to.throw()
     })
 
     it('works with matchers', () => {
-      const mock = mockFn(noop)
+      const mock = mockFn(sum)
 
-      mock(1, 2, 3)
+      mock(1, 2)
 
       expect(() => earl(mock).toHaveBeenCalledExactlyWith([[1, 2, earl.a(Number)]])).not.to.throw()
     })
 
     it('throws on partial matches', () => {
-      const mock = mockFn(noop)
+      const mock = mockFn(sum)
 
-      mock(1, 2, 3)
+      mock(1, 2)
 
       expect(() => earl(mock).toHaveBeenCalledExactlyWith([[1, 2]])).to.throw(
         'Mock was not called exactly with [[1, 2]] but was expected to',
@@ -41,9 +42,9 @@ describe('toHaveBeenCalledExactlyWith', () => {
 
   describe('negated', () => {
     it('throws when was called with a given args', () => {
-      const mock = mockFn(noop)
+      const mock = mockFn(sum)
 
-      mock(1, 2, 3)
+      mock(1, 2)
 
       expect(() => earl(mock).not.toHaveBeenCalledExactlyWith([[1, 2, 3]])).to.throw(
         "Mock was called exactly with [[1, 2, 3]] but wasn't expected to",
@@ -51,15 +52,15 @@ describe('toHaveBeenCalledExactlyWith', () => {
     })
 
     it("works when wasn't called with expected args", () => {
-      const mock = mockFn(noop)
+      const mock = mockFn(sum)
 
-      mock(1, 2, 3)
+      mock(1, 2)
 
       expect(() => earl(mock).not.toHaveBeenCalledExactlyWith([[1, 2]])).not.to.throw()
     })
 
     it('works with empty mocks', () => {
-      const mock = mockFn(noop)
+      const mock = mockFn(sum)
 
       expect(() => earl(mock).not.toHaveBeenCalledExactlyWith([])).to.throw(
         "Mock was called exactly with [] but wasn't expected to",

--- a/packages/earljs/test/validators/mocks/toHaveBeenCalledExactlyWith.test.ts
+++ b/packages/earljs/test/validators/mocks/toHaveBeenCalledExactlyWith.test.ts
@@ -3,7 +3,7 @@ import { expect } from 'chai'
 import { expect as earl } from '../../../src'
 import { mockFn } from '../../../src/mocks'
 
-const sum = (a: number, b: number) => a + b
+const sum = (a: number, b: number = 0) => a + b
 
 describe('toHaveBeenCalledExactlyWith', () => {
   describe('not negated', () => {
@@ -26,13 +26,13 @@ describe('toHaveBeenCalledExactlyWith', () => {
 
       mock(1, 2)
 
-      expect(() => earl(mock).toHaveBeenCalledExactlyWith([[1, 2, earl.a(Number)]])).not.to.throw()
+      expect(() => earl(mock).toHaveBeenCalledExactlyWith([[1, earl.a(Number)]])).not.to.throw()
     })
 
     it('throws on partial matches', () => {
       const mock = mockFn(sum)
 
-      mock(1, 2)
+      mock(1)
 
       expect(() => earl(mock).toHaveBeenCalledExactlyWith([[1, 2]])).to.throw(
         'Mock was not called exactly with [[1, 2]] but was expected to',
@@ -46,8 +46,8 @@ describe('toHaveBeenCalledExactlyWith', () => {
 
       mock(1, 2)
 
-      expect(() => earl(mock).not.toHaveBeenCalledExactlyWith([[1, 2, 3]])).to.throw(
-        "Mock was called exactly with [[1, 2, 3]] but wasn't expected to",
+      expect(() => earl(mock).not.toHaveBeenCalledExactlyWith([[1, 2]])).to.throw(
+        "Mock was called exactly with [[1, 2]] but wasn't expected to",
       )
     })
 
@@ -56,7 +56,7 @@ describe('toHaveBeenCalledExactlyWith', () => {
 
       mock(1, 2)
 
-      expect(() => earl(mock).not.toHaveBeenCalledExactlyWith([[1, 2]])).not.to.throw()
+      expect(() => earl(mock).not.toHaveBeenCalledExactlyWith([[1, 3]])).not.to.throw()
     })
 
     it('works with empty mocks', () => {


### PR DESCRIPTION
Closes: https://github.com/earl-js/earl/issues/88